### PR TITLE
Remember last enabled status setting

### DIFF
--- a/src/background/Background.js
+++ b/src/background/Background.js
@@ -29,15 +29,21 @@ browser.runtime.onInstalled.addListener(async details => {
 async function initalize() {
     console.log("initializing background listeners");
     await BlockHandler.updateRequestListener();
+    // TODO: decide what to do with "enable on browser startup" setting
     // browser.storage.local.get("settings").then(res => {
     //     enabled.setStatus(res.settings.enableOnStartup);
     // });
-    browser.storage.local.get("lastEnabledStatus").then(res => {
-        const status = res.lastEnabledStatus;
-        if (status !== undefined) {
-            enabled.setStatus(status);
-        } else {
-            enabled.setStatus(false);
+    browser.storage.local.get("settings").then(res => {
+        if (res.settings.rememberLastStatus) {
+            browser.storage.local.get("lastEnabledStatus").then(res => {
+                const status = res.lastEnabledStatus;
+                if (status !== undefined) {
+                    enabled.setStatus(status);
+                } else {
+                    // Key is not in storage, add it
+                    enabled.setStatus(false);
+                }
+            });
         }
     });
 }

--- a/src/background/Background.js
+++ b/src/background/Background.js
@@ -8,9 +8,9 @@ export let enabled = {
     setStatus(newStatus) {
         this.status = newStatus;
         updateIconState(this.status);
+        browser.storage.local.set({lastEnabledStatus: this.status})
     }
 };
-
 
 browser.runtime.onMessage.addListener(handleMessage);
 browser.runtime.onInstalled.addListener(async details => {
@@ -25,13 +25,22 @@ browser.runtime.onInstalled.addListener(async details => {
     await checkMissingSettings(await getActiveSettings());
     initalize();
 });
+
 async function initalize() {
     console.log("initializing background listeners");
     await BlockHandler.updateRequestListener();
-    browser.storage.local.get("settings").then(res => {
-        enabled.setStatus(res.settings.enableOnStartup);
+    // browser.storage.local.get("settings").then(res => {
+    //     enabled.setStatus(res.settings.enableOnStartup);
+    // });
+    browser.storage.local.get("lastEnabledStatus").then(res => {
+        const status = res.lastEnabledStatus;
+        if (status !== undefined) {
+            enabled.setStatus(status);
+        } else {
+            enabled.setStatus(false);
+        }
     });
-} 
+}
 initalize();
 
 async function handleMessage(request, sender, sendResponse) {

--- a/src/background/Background.js
+++ b/src/background/Background.js
@@ -8,7 +8,7 @@ export let enabled = {
     setStatus(newStatus) {
         this.status = newStatus;
         updateIconState(this.status);
-        browser.storage.local.set({lastEnabledStatus: this.status})
+        browser.storage.local.set({lastEnabledStatus: this.status});
     }
 };
 

--- a/src/settings/Settings.html
+++ b/src/settings/Settings.html
@@ -8,7 +8,10 @@
     <body>
         <h1 id="settingstext">Settings</h1>
         <div id="settingsContainer">
-            <label>Enable on browser startup <input class="setting" type="checkbox" id="enableOnStartup"/></label>
+            <!-- TODO: decide what to do with "enable on browser startup" setting -->
+            <!-- <label>Enable on browser startup <input class="setting" type="checkbox" id="enableOnStartup"/></label> -->
+            <!-- <br> -->
+            <label>Remember last enabled status on browser startup<input class="setting" type="checkbox" id="rememberLastStatus"/></label>
             <br>
             <label>Show the option to disable NoDistractions on the blocked page<input class="setting" type="checkbox" id="showDisableButton"/></label>
             <br>

--- a/src/shared/SettingsUtilities.js
+++ b/src/shared/SettingsUtilities.js
@@ -1,5 +1,7 @@
 const defaultSettings = {
-    enableOnStartup: false,
+    // TODO: decide what to do with "enable on browser startup" setting
+    // enableOnStartup: false,
+    rememberLastStatus: true,
     showDisableButton: true,
     showVisitAnyways: true,
     visitAnywaysLength: 3


### PR DESCRIPTION
Commented out the "enable on browser startup" setting related stuff, because these settings can't coexist, example:

* `enableOnStartup    = true`
* `rememberLastStatus = true`

Doesn't make sense when last status was `false` (disabled)

So we'll have to rethink if we want to keep the use case of
`enableOnStartup = true` in some form.
